### PR TITLE
Add Homebrew cask for macOS

### DIFF
--- a/Casks/scapectl.rb
+++ b/Casks/scapectl.rb
@@ -1,0 +1,40 @@
+cask "scapectl" do
+  version "0.0.12"
+  sha256 "1c9780c7453b3560ba02d3fef8fd45474368530d20b25f677558a192f74a7aa1"
+
+  url "https://github.com/charlietran/scapectl/releases/download/v#{version}/Mac_ScapeCtl.zip",
+      verified: "github.com/charlietran/scapectl/"
+  name "Scape Control"
+  desc "System tray app + CLI for the Fractal Design Scape wireless headset"
+  homepage "https://github.com/charlietran/scapectl"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  # Installs the .app into /Applications and symlinks the inner binary
+  # into Homebrew's bin so `scapectl` still works on the command line.
+  app "ScapeCtl.app"
+  binary "#{appdir}/ScapeCtl.app/Contents/MacOS/scapectl"
+
+  # The release binary is ad-hoc signed by the linker but not notarized.
+  # macOS Sequoia tracks both com.apple.quarantine and com.apple.provenance,
+  # and Gatekeeper rejects "downloaded ad-hoc" signatures with the
+  # "ScapeCtl.app is damaged" dialog (which auto-moves it to Trash).
+  # Strip all xattrs and re-sign locally — a fresh local ad-hoc signature
+  # is trusted by Gatekeeper where the downloaded one is not.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args:         ["-cr", "#{appdir}/ScapeCtl.app"],
+                   must_succeed: false
+    system_command "/usr/bin/codesign",
+                   args:         ["--force", "--deep", "--sign", "-", "#{appdir}/ScapeCtl.app"],
+                   must_succeed: false
+  end
+
+  zap trash: [
+    "~/Library/Application Support/scapectl",
+    "~/.config/scapectl",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -34,24 +34,25 @@ This is an unofficial app made for my own purposes, freely shared without any gu
 
 ## Install
 
+### Prebuilt downloads
+
+Grab the latest release for your platform from the [Releases page](https://github.com/charlietran/scapectl/releases). If you wish to compile yourself, see [Building from source](#building-from-source)
+
 ### Homebrew (macOS)
 
-```bash
+```sh
 brew tap charlietran/scapectl https://github.com/charlietran/scapectl
 brew install --cask scapectl
 ```
 
-Installs `ScapeCtl.app` into `/Applications` (launchable from Spotlight, addable to Login Items) and symlinks the `scapectl` CLI onto your `$PATH` for terminal/script use.
+Installs /Applications/ScapeCtl.app and symlinks the `scapectl` CLI onto your homebrew path
 
-To uninstall completely (removes the app and zaps the config directory):
+To uninstall:
 
-```bash
+```sh
 brew uninstall --cask --zap scapectl
 ```
 
-### Prebuilt downloads
-
-Grab the latest release for your platform from the [Releases page](https://github.com/charlietran/scapectl/releases). If you wish to compile yourself, see [Building from source](#building-from-source)
 
 ## Security and Privacy
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ This is an unofficial app made for my own purposes, freely shared without any gu
 
 ## Install
 
+### Homebrew (macOS)
+
+```bash
+brew tap charlietran/scapectl https://github.com/charlietran/scapectl
+brew install --cask scapectl
+```
+
+Installs `ScapeCtl.app` into `/Applications` (launchable from Spotlight, addable to Login Items) and symlinks the `scapectl` CLI onto your `$PATH` for terminal/script use.
+
+To uninstall completely (removes the app and zaps the config directory):
+
+```bash
+brew uninstall --cask --zap scapectl
+```
+
+### Prebuilt downloads
+
 Grab the latest release for your platform from the [Releases page](https://github.com/charlietran/scapectl/releases). If you wish to compile yourself, see [Building from source](#building-from-source)
 
 ## Security and Privacy

--- a/cmd/scapectl/main.go
+++ b/cmd/scapectl/main.go
@@ -54,6 +54,8 @@ func main() {
 			cmdSniff()
 		case "eq-code":
 			cmdEqCode(os.Args[2:])
+		case "version", "-v", "--version":
+			fmt.Printf("scapectl %s\n", version)
 		case "help", "-h", "--help":
 			cmdHelp()
 		default:
@@ -298,6 +300,7 @@ Usage:
   scapectl raw <hex>    Send raw HID report (for reverse engineering)
   scapectl sniff        Print all incoming HID data continuously
   scapectl eq-code      Decode/encode EQ preset codes
+  scapectl version      Print version
   scapectl help         Show this help
 
 Config:  ` + config.Path() + `

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -127,3 +127,22 @@ gh release create "${TAG}" \
     "${BUILD_DIR}/Win_ScapeCtl.zip"
 
 echo "==> Done! Release ${TAG} created."
+
+# ── Bump Homebrew cask ──
+# Only runs locally (skipped in CI to avoid pushing to main without extra auth).
+
+if [[ -z "${GITHUB_ACTIONS:-}" && -f Casks/scapectl.rb ]]; then
+    echo "==> Bumping Homebrew cask to ${VERSION}..."
+    ZIP_SHA=$(shasum -a 256 "${BUILD_DIR}/Mac_ScapeCtl.zip" | awk '{print $1}')
+    sed -i.bak -E \
+        -e "s|version \"[0-9]+\.[0-9]+\.[0-9]+\"|version \"${VERSION}\"|" \
+        -e "s|sha256 \"[0-9a-f]{64}\"|sha256 \"${ZIP_SHA}\"|" \
+        Casks/scapectl.rb
+    rm -f Casks/scapectl.rb.bak
+    if ! git diff --quiet Casks/scapectl.rb; then
+        git add Casks/scapectl.rb
+        git commit -m "Bump cask to ${TAG}"
+        git push origin HEAD
+        echo "==> Cask bumped and pushed."
+    fi
+fi


### PR DESCRIPTION
adds a homebrew cask so mac users can `brew install --cask scapectl` instead of grabbing the zip from releases 

drops ScapeCtl.app straight into /Applications and symlinks the inner binary so the CLI works too!

Possible to do this in a Mac and Linuxbrew-compatible way by using the CLI + `brew services` but I like the `.app` on my Mac

went with an in-repo Casks/ dir rather than a separate charlietran/homebrew-scapectl tap repo — keeps everything in one place, no cross-repo tokens, the release script just edits the cask in place. tradeoff is users need the explicit URL form of brew tap.

once merged would be:

```
brew tap charlietran/scapectl https://github.com/charlietran/scapectl
brew install --cask scapectl
```


Would be good for someone else to test this. One thing to note:
- postflight strips quarantine + re-signs ad-hoc locally — macOS sequoia rejects "downloaded ad-hoc" signatures with the "damaged" dialog (and auto-moves the .app to trash) even though the binary itself is fine; a fresh local sig defeats this
- new `scapectl version` subcommand
- README install section now leads with the brew cask flow
- tools/release.sh auto-bumps the cask's version + sha256 after each gh release create (local-only, skipped in CI)

Lastly, a dedicated charlietran/homebrew-scapectl tap would let people skip the URL and just `brew install --cask charlietran/scapectl/scapectl`, but it adds a second repo to keep in sync. easy upgrade path later if you want it.

to test:
- `brew tap jamiew/scapectl https://github.com/jamiew/scapectl && brew install --cask jamiew/scapectl/scapectl` (my fork)
- launch ScapeCtl.app from Spotlight or /Applications — should open cleanly, no "damaged" dialog
- `scapectl help` from a terminal — CLI still works via the symlink
- `brew uninstall --cask scapectl — clean`