### PR TITLE
Key trigger `cooldown` by event, not just script

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ cooldown = 5
 | `event`    | Yes      | Event name (see table below)                                                                                                           |
 | `script`   | Yes      | Shell command to run                                                                                                                   |
 | `enabled`  | Yes      | `true` or `false`                                                                                                                      |
-| `cooldown` | No       | Minimum seconds between firings (default: 0). Prevents the same script from running repeatedly if the event fires in quick succession. |
+| `cooldown` | No       | Minimum seconds between firings (default: 0). Prevents a rule from running repeatedly if the event fires in quick succession. Tracked per event, so two events can share one script without sharing a cooldown. |
 | `battery`  | No       | For `BatteryLevel` only: fire when battery <= this % (default: 20)                                                                     |
 
 ### Available events

--- a/internal/triggers/triggers.go
+++ b/internal/triggers/triggers.go
@@ -29,7 +29,7 @@ import (
 type Runner struct {
 	cfg      *config.Config
 	mu       sync.Mutex
-	lastFire map[string]time.Time // label → last fire time (for cooldown)
+	lastFire map[string]time.Time // event+script → last fire time (for cooldown)
 }
 
 // New creates a trigger runner with the given config.
@@ -95,16 +95,18 @@ func (r *Runner) dispatch(evt monitor.Event) {
 			}
 		}
 
-		// Cooldown: skip if fired too recently
+		// Cooldown: skip if fired too recently. Keyed by event+script so two
+		// events sharing one script don't share a cooldown.
 		if rule.Cooldown > 0 {
+			key := rule.Event + "\x00" + rule.Script
 			r.mu.Lock()
-			last, exists := r.lastFire[rule.Script]
+			last, exists := r.lastFire[key]
 			cooldownDur := time.Duration(rule.Cooldown) * time.Second
 			if exists && time.Since(last) < cooldownDur {
 				r.mu.Unlock()
 				continue
 			}
-			r.lastFire[rule.Script] = time.Now()
+			r.lastFire[key] = time.Now()
 			r.mu.Unlock()
 		}
 


### PR DESCRIPTION
Two triggers pointing at the same script silently share one cooldown, because the cooldown map is keyed by the script string alone. The second event gets swallowed. This keys it by event + script.

It bites as soon as one script handles both power events and branches on `$SCAPE_EVENT`, which is the natural shape for audio switching:

```toml
[[triggers]]
event    = "HeadsetPowerOn"
script   = "bash ~/audio-switch.sh"
enabled  = true
cooldown = 5

[[triggers]]
event    = "HeadsetPowerOff"
script   = "bash ~/audio-switch.sh"
enabled  = true
cooldown = 5
```

Power the headset off within 5s of powering it on and the restore never runs, so audio stays on a device that's gone. The README's examples dodge this by using two different one-liners.
