### PR TITLE
Modernize Homebrew cask

### DIFF
--- a/Casks/scapectl.rb
+++ b/Casks/scapectl.rb
@@ -2,8 +2,7 @@ cask "scapectl" do
   version "0.0.14"
   sha256 :no_check
 
-  url "https://github.com/charlietran/scapectl/releases/download/v#{version}/Mac_ScapeCtl.zip",
-      verified: "github.com/charlietran/scapectl/"
+  url "https://github.com/charlietran/scapectl/releases/download/v#{version}/Mac_ScapeCtl.zip"
   name "Scape Control"
   desc "System tray app + CLI for the Fractal Design Scape wireless headset"
   homepage "https://github.com/charlietran/scapectl"
@@ -12,6 +11,8 @@ cask "scapectl" do
     url :url
     strategy :github_latest
   end
+
+  depends_on :macos
 
   # Installs the .app into /Applications and symlinks the inner binary
   # into Homebrew's bin so `scapectl` still works on the command line.
@@ -24,17 +25,17 @@ cask "scapectl" do
   # "ScapeCtl.app is damaged" dialog (which auto-moves it to Trash).
   # Strip all xattrs and re-sign locally — a fresh local ad-hoc signature
   # is trusted by Gatekeeper where the downloaded one is not.
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args:         ["-cr", "#{appdir}/ScapeCtl.app"],
-                   must_succeed: false
-    system_command "/usr/bin/codesign",
-                   args:         ["--force", "--deep", "--sign", "-", "#{appdir}/ScapeCtl.app"],
-                   must_succeed: false
+  postflight_steps do
+    run "/usr/bin/xattr",
+        args:         ["-cr", "{{appdir}}/ScapeCtl.app"],
+        must_succeed: false
+    run "/usr/bin/codesign",
+        args:         ["--force", "--deep", "--sign", "-", "{{appdir}}/ScapeCtl.app"],
+        must_succeed: false
   end
 
   zap trash: [
-    "~/Library/Application Support/scapectl",
     "~/.config/scapectl",
+    "~/Library/Application Support/scapectl",
   ]
 end


### PR DESCRIPTION
removes deprecated URL verification syntax and migrating postflight commands. It also adds the explicit macOS dependency and fixes current style issues

silences a bunch of homebrew warnings when installing